### PR TITLE
feat(editor): make focused entity visible in screen when not in viewport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.1.1",
         "react-router": "^7.7.1",
-        "sparkengineweb": "https://github.com/RuggeroVisintin/SparkEngineWeb/releases/download/sparkengineweb-v0.16.2/sparkengineweb-v0.16.2-lib.tar.gz",
+        "sparkengineweb": "https://github.com/RuggeroVisintin/SparkEngineWeb/releases/download/sparkengineweb-v0.16.3/sparkengineweb-v0.16.3-lib.tar.gz",
         "styled-components": "^6.1.19",
         "text-encoding": "^0.7.0",
         "uuid": "^11.1.0",
@@ -17067,9 +17067,9 @@
       "license": "MIT"
     },
     "node_modules/sparkengineweb": {
-      "version": "0.16.2",
-      "resolved": "https://github.com/RuggeroVisintin/SparkEngineWeb/releases/download/sparkengineweb-v0.16.2/sparkengineweb-v0.16.2-lib.tar.gz",
-      "integrity": "sha512-IdX/EKrdjtd4Xude7UyFZtd3hcePVyanBcERU3aRO3eqMv59NqwRoVclfEEpyohLkDTPU9ErehVDr/JO0HVAYA==",
+      "version": "0.16.3",
+      "resolved": "https://github.com/RuggeroVisintin/SparkEngineWeb/releases/download/sparkengineweb-v0.16.3/sparkengineweb-v0.16.3-lib.tar.gz",
+      "integrity": "sha512-QiGpP3uAHNxRUVwJ7midQDL8CazrMJzH8xHIHFFW7jd+4Ek98bspIsUoaw0OR20pc0/UI7NnkVmhyaV7x/rdXQ==",
       "license": "GNU GPL v2",
       "dependencies": {
         "uuid": "^11.1.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.1.1",
     "react-router": "^7.7.1",
-    "sparkengineweb": "https://github.com/RuggeroVisintin/SparkEngineWeb/releases/download/sparkengineweb-v0.16.2/sparkengineweb-v0.16.2-lib.tar.gz",
+    "sparkengineweb": "https://github.com/RuggeroVisintin/SparkEngineWeb/releases/download/sparkengineweb-v0.16.3/sparkengineweb-v0.16.3-lib.tar.gz",
     "styled-components": "^6.1.19",
     "text-encoding": "^0.7.0",
     "uuid": "^11.1.0",

--- a/src/core/editor/application/EditorService.test.tsx
+++ b/src/core/editor/application/EditorService.test.tsx
@@ -225,6 +225,7 @@ describe('EditorService', () => {
                 editorService.handleMouseClick({
                     targetX: 100,
                     targetY: 100,
+                    modifiers: {},
                     button: 1
                 });
 

--- a/src/core/editor/domain/ContextualUiService.test.tsx
+++ b/src/core/editor/domain/ContextualUiService.test.tsx
@@ -1,11 +1,11 @@
-import { GameObject, Scene, TransformComponent, Vec2 } from "sparkengineweb";
+import { CameraComponent, GameObject, Scene, TransformComponent, Vec2 } from "sparkengineweb";
 import { ContextualUiService } from "./ContextualUiService";
 
 describe('core/editor/ContextualUiService', () => {
     let service: ContextualUiService;
     let contextualUiScene: Scene;
 
-    beforeAll(() => {
+    beforeEach(() => {
         contextualUiScene = new Scene();
         service = new ContextualUiService();
 
@@ -65,16 +65,12 @@ describe('core/editor/ContextualUiService', () => {
 
         it('Should center the camera on the entity if not in viewport', () => {
             const entity = new GameObject();
-            entity.transform.size.height = 50;
-            entity.transform.size.width = 100;
+            entity.transform.position = new Vec2(2000, 2000);
 
             service.focusOnEntity(entity);
 
-            const cameraPosition = service.editorCamera.getComponent<TransformComponent>('TransformComponent')?.position;
-            expect(cameraPosition).toEqual(expect.objectContaining({
-                x: entity.transform.position.x,
-                y: entity.transform.position.y
-            }));
+            const cameraPosition = service.editorCamera.getComponent<CameraComponent>('CameraComponent')?.transform.position;
+            expect(cameraPosition).toEqual(entity.transform.position);
         });
     })
 

--- a/src/core/editor/domain/ContextualUiService.test.tsx
+++ b/src/core/editor/domain/ContextualUiService.test.tsx
@@ -1,4 +1,4 @@
-import { GameObject, Scene, Vec2 } from "sparkengineweb";
+import { GameObject, Scene, TransformComponent, Vec2 } from "sparkengineweb";
 import { ContextualUiService } from "./ContextualUiService";
 
 describe('core/editor/ContextualUiService', () => {
@@ -61,6 +61,20 @@ describe('core/editor/ContextualUiService', () => {
             service.focusOnEntity(entity);
 
             expect(service.currentEntityOriginPivot.transform.size).toEqual({ width: 10, height: 10 });
+        });
+
+        it('Should center the camera on the entity if not in viewport', () => {
+            const entity = new GameObject();
+            entity.transform.size.height = 50;
+            entity.transform.size.width = 100;
+
+            service.focusOnEntity(entity);
+
+            const cameraPosition = service.editorCamera.getComponent<TransformComponent>('TransformComponent')?.position;
+            expect(cameraPosition).toEqual(expect.objectContaining({
+                x: entity.transform.position.x,
+                y: entity.transform.position.y
+            }));
         });
     })
 

--- a/src/core/editor/domain/ContextualUiService.tsx
+++ b/src/core/editor/domain/ContextualUiService.tsx
@@ -1,4 +1,4 @@
-import { IEntity, Rgb, Scene, Vec2 } from "sparkengineweb";
+import { CameraComponent, GameEngine, IEntity, isCollision, Rgb, Scene, TransformComponent, Vec2 } from "sparkengineweb";
 import { EntityOutline } from "./entities";
 import Pivot from "./entities/Pivot";
 import { EditorCamera } from "./entities/EditrorCamera";
@@ -41,6 +41,23 @@ export class ContextualUiService {
         this._currentEntityOutline.match(entity);
 
         this._currentEntityOriginPivot.transform.size = { width: 10, height: 10 };
+
+        const entityTransform = entity.getComponent<TransformComponent>("TransformComponent");
+        const cameraTransform = this._editorCamera.getComponent<CameraComponent>("CameraComponent")?.transform;
+
+        if (entityTransform && cameraTransform && !isCollision([
+            entityTransform.position.x,
+            entityTransform.position.y,
+            entityTransform.size.width,
+            entityTransform.size.height
+        ], [
+            cameraTransform.position.x,
+            cameraTransform.position.y,
+            cameraTransform.size.width,
+            cameraTransform.size.height
+        ])) {
+            cameraTransform.position = Vec2.from(entityTransform.position);
+        }
     }
 
     public loseFocus(): void {

--- a/src/core/editor/domain/ObjectPickingService.test.tsx
+++ b/src/core/editor/domain/ObjectPickingService.test.tsx
@@ -3,13 +3,14 @@ import { ObjectPickingService } from "./ObjectPickingService";
 
 
 describe('core/editor/ObjectPickingService', () => {
+    const event = { button: 0, targetX: 100, targetY: 200, modifiers: {} };
+
     describe('.handleMouseClick()', () => {
         it('Should pick the object at the given coordinates on left mouse click', () => {
             const objectPickerMock = {
                 pick: jest.fn(() => new GameObject()),
             };
             const service = new ObjectPickingService(objectPickerMock as any);
-            const event = { button: 0, targetX: 100, targetY: 200 };
 
             service.handleMouseClick(event);
 
@@ -20,10 +21,9 @@ describe('core/editor/ObjectPickingService', () => {
             const objectPickerMock = {
                 pick: jest.fn(() => new GameObject()),
             };
-            const service = new ObjectPickingService(objectPickerMock as any);
-            const event = { button: 1, targetX: 100, targetY: 200 };
 
-            service.handleMouseClick(event);
+            const service = new ObjectPickingService(objectPickerMock as any);
+            service.handleMouseClick({ ...event, button: 1 });
 
             expect(service.selectedEntity).toBeUndefined();
         });
@@ -33,7 +33,6 @@ describe('core/editor/ObjectPickingService', () => {
                 pick: jest.fn(() => undefined),
             };
             const service = new ObjectPickingService(objectPickerMock as any);
-            const event = { button: 0, targetX: 100, targetY: 200 };
 
             service.handleMouseClick(event);
 
@@ -46,7 +45,6 @@ describe('core/editor/ObjectPickingService', () => {
             };
             const callbackMock = jest.fn();
             const service = new ObjectPickingService(objectPickerMock as any);
-            const event = { button: 0, targetX: 100, targetY: 200 };
 
             service.handleMouseClick(event, callbackMock);
 

--- a/src/core/editor/domain/entities/EditorCamera.test.tsx
+++ b/src/core/editor/domain/entities/EditorCamera.test.tsx
@@ -13,7 +13,7 @@ describe('core/debug/EditorCamera', () => {
         const cameraComponent = camera.getComponent<CameraComponent>('CameraComponent');
 
         expect(cameraComponent).toBeDefined();
-        expect(camera.transform.size).toEqual({ width: 1920, height: 1080 });
+        expect(cameraComponent?.transform.size).toEqual({ width: 1920, height: 1080 });
     });
 
     it('Should have the correct type', () => {

--- a/src/core/editor/domain/entities/EditorCamera.test.tsx
+++ b/src/core/editor/domain/entities/EditorCamera.test.tsx
@@ -1,4 +1,4 @@
-import { BaseEntity, typeOf } from 'sparkengineweb';
+import { BaseEntity, CameraComponent, typeOf } from 'sparkengineweb';
 import { EditorCamera } from './EditrorCamera';
 
 describe('core/debug/EditorCamera', () => {
@@ -10,7 +10,10 @@ describe('core/debug/EditorCamera', () => {
     it('Should have a camera component registered by default', () => {
         const camera = new EditorCamera();
 
-        expect(camera.getComponent('CameraComponent')).toBeDefined();
+        const cameraComponent = camera.getComponent<CameraComponent>('CameraComponent');
+
+        expect(cameraComponent).toBeDefined();
+        expect(camera.transform.size).toEqual({ width: 1920, height: 1080 });
     });
 
     it('Should have the correct type', () => {

--- a/src/core/editor/domain/entities/EditrorCamera.tsx
+++ b/src/core/editor/domain/entities/EditrorCamera.tsx
@@ -6,5 +6,6 @@ export class EditorCamera extends GameObject {
         super();
 
         this.addComponent(new CameraComponent());
+        this.transform.size = { width: 1920, height: 1080 };
     }
 }

--- a/src/core/editor/domain/entities/EditrorCamera.tsx
+++ b/src/core/editor/domain/entities/EditrorCamera.tsx
@@ -1,11 +1,17 @@
-import { CameraComponent, GameObject, Type } from "sparkengineweb";
+import { BaseEntity, CameraComponent, GameObject, Type } from "sparkengineweb";
 
 @Type('EditorCamera')
-export class EditorCamera extends GameObject {
+export class EditorCamera extends BaseEntity {
     constructor() {
         super();
 
-        this.addComponent(new CameraComponent());
-        this.transform.size = { width: 1920, height: 1080 };
+        const cameraComponent = new CameraComponent({
+            transform: {
+                size: { width: 1920, height: 1080 }
+            }
+        })
+
+        this.addComponent(cameraComponent);
+        this.addComponent(cameraComponent.transform)
     }
 }


### PR DESCRIPTION
Moves the camera to the focused entity's position to ensure it is visible in the editor viewport

Closes #192 