### PR TITLE
feat: add dedicated preview page route

### DIFF
--- a/e2e/EditorPage.e2e.test.ts
+++ b/e2e/EditorPage.e2e.test.ts
@@ -49,7 +49,7 @@ describe('Editor Page - Components Panel', () => {
             await page.getByRole('option', { name: /Preview/i }).click();
 
             await expect(page.getByLabel(/Engine View/i)).toBeVisible();
-            await expect(page.getByRole('button', { name: /Add GameObject/i })).not.toBeVisible();
+            await expect(page.getByRole('option', { name: /Add GameObject/i })).not.toBeVisible();
         });
     });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import { Routes, Route } from 'react-router';
 import { Editor } from './pages/Editor';
-import { Scripting } from './pages';
+import { Preview, Scripting } from './pages';
 
 export const App = () => {
     return (
         <Routes>
             <Route path="/" element={<Editor />} />
+            <Route path="/preview" element={<Preview />} />
             <Route path="/scripting/:entityUuid/:componentUuid/:callbackPropertyName" element={<Scripting />} />
             {/* Add more routes as needed */}
         </Routes>

--- a/src/pages/Editor/index.tsx
+++ b/src/pages/Editor/index.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { useNavigate } from 'react-router';
 import { GameEngine, IComponent, IEntity } from '@sparkengine';
 import { EngineView } from '../../components';
 import { Box, FlexBox } from '../../primitives';
@@ -13,6 +14,7 @@ import { getAllAvailableComponents } from '../../core/common';
 export const Editor = () => {
     const engine = useRef<GameEngine>();
     const [editorService, editorState] = useEditorService();
+    const navigate = useNavigate();
 
     const onEngineViewReady = async ({ context, resolution }: OnEngineViewReadyCBProps) => {
         editorService.start(context, resolution);
@@ -26,6 +28,7 @@ export const Editor = () => {
             <ActionMenu
                 onProjectFileOpen={() => editorService.openProject()}
                 onProjectFileSave={() => editorService.saveProject()}
+                onPreviewOpen={() => navigate('/preview')}
             />
             <FlexBox $direction='row' $fill style={{ overflow: 'hidden' }}>
                 <EntityFactoryPanel

--- a/src/pages/Preview/index.tsx
+++ b/src/pages/Preview/index.tsx
@@ -1,0 +1,24 @@
+import { useRef } from 'react';
+import { GameEngine } from '@sparkengine';
+import { EngineView } from '../../components';
+import { FlexBox } from '../../primitives';
+import { OnEngineViewReadyCBProps } from '../../components/EngineView';
+import { useEditorService } from '../../hooks/useEditorService';
+
+export const Preview = () => {
+    const engine = useRef<GameEngine | undefined>(undefined);
+    const [editorService] = useEditorService();
+
+    const onEngineViewReady = async ({ context, resolution }: OnEngineViewReadyCBProps) => {
+        editorService.start(context, resolution);
+        const newEngine = editorService.engine;
+
+        engine.current = newEngine;
+    };
+
+    return (
+        <FlexBox $fill={true}>
+            <EngineView onEngineViewReady={onEngineViewReady} />
+        </FlexBox>
+    )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,2 +1,3 @@
 export * from './Editor';
+export * from './Preview';
 export * from './Scripting';


### PR DESCRIPTION
## Summary
- route `/preview` to a dedicated `Preview` page instead of reusing `Editor` with mode props
- keep `Editor` focused on editor-only responsibilities and keep Preview isolated
- export the new page from the pages barrel
- keep preview navigation behavior validated from the editor action menu

Feature-Flag: PREVIEW_MODE

Closes #360 